### PR TITLE
fix: update CLI command from 'auth' to 'configure'

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pnpm add -g rn-icofy
 
 ```bash
 # 1️⃣ Authenticate (set your API key)
-icofy auth
+icofy configure
 
 # 2️⃣ Generate a stunning new app icon
 icofy generate


### PR DESCRIPTION
I keep getting this error when I run `icofy auth` and I found out that it has been renamed to `icofy configure`. So I fixed the docs. See here:

<img width="871" height="115" alt="Screenshot 2025-08-25 at 7 05 34 PM" src="https://github.com/user-attachments/assets/1abf90f0-8af7-41bd-82e7-7b1366b1e9d4" />
